### PR TITLE
fix(versions): update Activiti/activiti-cloud-application-chart versions

### DIFF
--- a/charts/application/requirements.yaml
+++ b/charts/application/requirements.yaml
@@ -20,7 +20,7 @@ dependencies:
   alias: "rabbitmq"
 - name: "example-runtime-bundle"
   repository: "https://activiti.github.io/activiti-cloud-helm-charts/"
-  version: "7.0.97"
+  version: "7.0.98"
   condition: "application.runtime-bundle.enabled,runtime-bundle.enabled"
   alias: "runtime-bundle"
 - name: "example-cloud-connector"


### PR DESCRIPTION
[UpdateBot](https://github.com/jenkins-x/updatebot) pushed helm dependency: `example-runtime-bundle` to: `7.0.98`