### PR TITLE
fix(versions): update Activiti/activiti-cloud-application-chart versions

### DIFF
--- a/charts/application/requirements.yaml
+++ b/charts/application/requirements.yaml
@@ -25,7 +25,7 @@ dependencies:
   alias: "runtime-bundle"
 - name: "example-cloud-connector"
   repository: "https://activiti.github.io/activiti-cloud-helm-charts/"
-  version: "7.1.20"
+  version: "7.1.21"
   condition: "application.activiti-cloud-connector.enabled,activiti-cloud-connector.enabled"
   alias: "activiti-cloud-connector"
 - name: "activiti-cloud-events-adapter"


### PR DESCRIPTION
[UpdateBot](https://github.com/jenkins-x/updatebot) pushed helm dependency: `example-cloud-connector` to: `7.1.21`